### PR TITLE
Poprawilam resize obrazkow z herbatą

### DIFF
--- a/BooTea-game/Assets/Scenes/SampleScene.unity
+++ b/BooTea-game/Assets/Scenes/SampleScene.unity
@@ -160,6 +160,14 @@ PrefabInstance:
       value: 100
       objectReference: {fileID: 0}
     - target: {fileID: 8147131105462844588, guid: dd06bca9e6a16fe40b3540f14c085723, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8147131105462844588, guid: dd06bca9e6a16fe40b3540f14c085723, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8147131105462844588, guid: dd06bca9e6a16fe40b3540f14c085723, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
@@ -25831,6 +25839,14 @@ PrefabInstance:
     - target: {fileID: 6087836848369618277, guid: 0ec21dabcd64f69478687f27e1b62637, type: 3}
       propertyPath: m_SizeDelta.y
       value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 6087836848369618277, guid: 0ec21dabcd64f69478687f27e1b62637, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6087836848369618277, guid: 0ec21dabcd64f69478687f27e1b62637, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6087836848369618277, guid: 0ec21dabcd64f69478687f27e1b62637, type: 3}
       propertyPath: m_LocalPosition.x

--- a/BooTea-game/Assets/UI/Herbatki/Iced Matcha.png.meta
+++ b/BooTea-game/Assets/UI/Herbatki/Iced Matcha.png.meta
@@ -51,7 +51,7 @@ TextureImporter:
   spriteMeshType: 1
   alignment: 0
   spritePivot: {x: 0.5, y: 0.5}
-  spritePixelsToUnits: 100
+  spritePixelsToUnits: 32
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1

--- a/BooTea-game/Assets/UI/Herbatki/Jar of Honey.png.meta
+++ b/BooTea-game/Assets/UI/Herbatki/Jar of Honey.png.meta
@@ -51,7 +51,7 @@ TextureImporter:
   spriteMeshType: 1
   alignment: 0
   spritePivot: {x: 0.5, y: 0.5}
-  spritePixelsToUnits: 100
+  spritePixelsToUnits: 32
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1

--- a/BooTea-game/Assets/UI/Herbatki/Lemon.png.meta
+++ b/BooTea-game/Assets/UI/Herbatki/Lemon.png.meta
@@ -51,7 +51,7 @@ TextureImporter:
   spriteMeshType: 1
   alignment: 0
   spritePivot: {x: 0.5, y: 0.5}
-  spritePixelsToUnits: 100
+  spritePixelsToUnits: 32
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1

--- a/BooTea-game/Assets/UI/Herbatki/Matcha Latte (Leaf).png.meta
+++ b/BooTea-game/Assets/UI/Herbatki/Matcha Latte (Leaf).png.meta
@@ -51,7 +51,7 @@ TextureImporter:
   spriteMeshType: 1
   alignment: 0
   spritePivot: {x: 0.5, y: 0.5}
-  spritePixelsToUnits: 100
+  spritePixelsToUnits: 32
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1

--- a/BooTea-game/Assets/UI/Herbatki/Pudding.png.meta
+++ b/BooTea-game/Assets/UI/Herbatki/Pudding.png.meta
@@ -51,7 +51,7 @@ TextureImporter:
   spriteMeshType: 1
   alignment: 0
   spritePivot: {x: 0.5, y: 0.5}
-  spritePixelsToUnits: 100
+  spritePixelsToUnits: 32
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1

--- a/BooTea-game/Assets/UI/Herbatki/Royal Earl Grey.png.meta
+++ b/BooTea-game/Assets/UI/Herbatki/Royal Earl Grey.png.meta
@@ -51,7 +51,7 @@ TextureImporter:
   spriteMeshType: 1
   alignment: 0
   spritePivot: {x: 0.5, y: 0.5}
-  spritePixelsToUnits: 100
+  spritePixelsToUnits: 32
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1


### PR DESCRIPTION
Obrazki z herbatą miały złe ustawienia. Gdy robimy grę 2D ważne jest aby nie dodawać filtrów na zdjęcie i nadać im odpowiednio size 32 skoro Maja narysowała te obrazki w 32x32 px. W załączniku screen z ustawień filtrów.

Sprite Mode: Single albo Multiple w zależności czy na obrazku jest tylko jeden item, czy więcej jak w przypadku tego obrazka z Furniture.
Pixels Per Unit: 32 (bo taki rozmiar ma obrazek Mai)
Filter Mode: Point (no filter)
Compression: None
![obraz_2025-04-10_114555218](https://github.com/user-attachments/assets/736236a2-454a-448d-af07-604de0f32077)

Bardzo podobny problem był z dymkiem z wykrzyknikiem - był rozmazany, bo te filtry nie były dodane. Sprawdzajcie to bo ważne!!